### PR TITLE
[Feat] : 게시글 검색 keyword를 공백으로 검색 시 전체 게시글 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/turtledoctor/kgu/post/service/PostService.java
+++ b/src/main/java/com/turtledoctor/kgu/post/service/PostService.java
@@ -115,25 +115,25 @@ public class PostService {
     @Transactional(readOnly = true)
     public List<PostListResponse> createSearchedPostListDTO(SearchPostRequest postSearchRequestDTO) {
         String keyword = postSearchRequestDTO.getKeyword();
-        List<PostListResponse> postList;
+        List<Post> rawSearchedPostList;
 
         if(keyword.isBlank()) {
-            postList = createPostListDTO();
+            rawSearchedPostList = postRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"));
         }
         else {
-            List<Post> rawSearchedPostList = postRepository.findAllByTitleContainingOrBodyContainingOrderByCreatedAtDesc(keyword, keyword);
-            postList = new ArrayList<>();
+            rawSearchedPostList = postRepository.findAllByTitleContainingOrBodyContainingOrderByCreatedAtDesc(keyword, keyword);
+        }
 
-            for(Post post : rawSearchedPostList) {
-                PostListResponse dto = PostListResponse.builder()
-                        .id(post.getId())
-                        .title(post.getTitle())
-                        .content(post.getBody())
-                        .nickname(post.getMember().getName())
-                        .date(DateConverter.ConverteDate(post.getCreatedAt()))
-                        .build();
-                postList.add(dto);
-            }
+        List<PostListResponse> postList= new ArrayList<>();
+        for(Post post : rawSearchedPostList) {
+            PostListResponse dto = PostListResponse.builder()
+                    .id(post.getId())
+                    .title(post.getTitle())
+                    .content(post.getBody())
+                    .nickname(post.getMember().getName())
+                    .date(DateConverter.ConverteDate(post.getCreatedAt()))
+                    .build();
+            postList.add(dto);
         }
         return postList;
     }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #56 

## ✅ 작업 내용

- [ ] createSearchedPostListDTO 메소드에서 공백 입력 시 전체 리스트 반환하도록 로직 변경

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
