### PR TITLE
[Refactor] : jwt 토큰 생성 시 name, email의 민감한 정보 제거, Jwt signiture claim에서 depre…

### DIFF
--- a/src/main/java/com/turtledoctor/kgu/auth/dto/LoginDTO.java
+++ b/src/main/java/com/turtledoctor/kgu/auth/dto/LoginDTO.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 @Getter
 @Builder
-@Setter
 public class LoginDTO {
     private String name;
     private UserRole userRole;

--- a/src/main/java/com/turtledoctor/kgu/auth/dto/LoginDTO.java
+++ b/src/main/java/com/turtledoctor/kgu/auth/dto/LoginDTO.java
@@ -2,13 +2,11 @@ package com.turtledoctor.kgu.auth.dto;
 
 
 import com.turtledoctor.kgu.entity.enums.UserRole;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Builder
+@Setter
 public class LoginDTO {
     private String name;
     private UserRole userRole;

--- a/src/main/java/com/turtledoctor/kgu/auth/jwt/JWTFilter.java
+++ b/src/main/java/com/turtledoctor/kgu/auth/jwt/JWTFilter.java
@@ -9,13 +9,14 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.catalina.User;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Enumeration;
 
@@ -39,7 +40,7 @@ public class JWTFilter extends OncePerRequestFilter {
         }
         for (Cookie cookie : cookies) {
 
-            System.out.println(cookie.getName());
+//            System.out.println(cookie.getName());
             if (cookie.getName().equals("Authorization")) {
 
                 authorization = cookie.getValue();
@@ -63,16 +64,16 @@ public class JWTFilter extends OncePerRequestFilter {
 
         //토큰에서 kakaoId과 role 획득
         String kakaoId = jwtUtil.getkakaoId(token);
-        String name = jwtUtil.getName(token); // 추가
-        String email = jwtUtil.getEmail(token); // 추가
-        log.info(email+"\n12341234");
+//        String name = jwtUtil.getName(token); // 제거
+//        String email = jwtUtil.getEmail(token); // 제거
+        log.info("[" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss:SSS")) + "]JWTFilter 거친 카카오 id : " + kakaoId + "\n");
         String role = jwtUtil.getRole(token);
 
         //userDTO를 생성하여 값 set
         UserDTO userDTO = new UserDTO();
         userDTO.setKakaoId(kakaoId);
-        userDTO.setName(name); // 추가
-        userDTO.setEmail(email); // 추가
+//        userDTO.setName(name); // 제거
+//        userDTO.setEmail(email); // 제거
         userDTO.setRole(role);
 
         //UserDetails에 회원 정보 객체 담기

--- a/src/main/java/com/turtledoctor/kgu/auth/jwt/JWTUtil.java
+++ b/src/main/java/com/turtledoctor/kgu/auth/jwt/JWTUtil.java
@@ -41,7 +41,7 @@ public class JWTUtil {
 
     private Claims getClaims(String token) {
         try {
-            //Jwts.parser() 대신 JWTParserBuilder 사용으로 변경
+            //jwts의 deprecated 된 코드 부분 수정
             return Jwts.parser()
                     .setSigningKey(secretKey)
                     .build().parseSignedClaims(token).getPayload();

--- a/src/main/java/com/turtledoctor/kgu/auth/jwt/JWTUtil.java
+++ b/src/main/java/com/turtledoctor/kgu/auth/jwt/JWTUtil.java
@@ -26,12 +26,12 @@ public class JWTUtil {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
-    public String createJwt(String kakaoId, String name, String email, String role, Long expiredMs) { // 추가 name, email
+    public String createJwt(String kakaoId, String role, Long expiredMs) {
 
         return Jwts.builder()
                 .claim("kakaoId", kakaoId)
-                .claim("name", name)
-                .claim("email", email)
+//                .claim("name", name) // 제거
+//                .claim("email", email) // 제거
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
@@ -41,11 +41,10 @@ public class JWTUtil {
 
     private Claims getClaims(String token) {
         try {
+            //Jwts.parser() 대신 JWTParserBuilder 사용으로 변경
             return Jwts.parser()
                     .setSigningKey(secretKey)
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody();
+                    .build().parseSignedClaims(token).getPayload();
         } catch (SignatureException e) {
             log.error("JWT signature error: {}", e.getMessage());
             throw new AuthException(INVALID_JWT_SIGNATURE);
@@ -63,13 +62,13 @@ public class JWTUtil {
         return getClaims(token).get("role", String.class);
     }
 
-    public String getEmail(String token) { // 추가
-        return getClaims(token).get("email", String.class);
-    }
+//    public String getEmail(String token) { // 추가
+//        return getClaims(token).get("email", String.class);
+//    }
 
-    public String getName(String token) { // 추가
-        return getClaims(token).get("name", String.class);
-    }
+//    public String getName(String token) { // 추가
+//        return getClaims(token).get("name", String.class);
+//    }
 
     public Boolean isExpired(String token) {
         return getClaims(token).getExpiration().before(new Date());
@@ -77,12 +76,5 @@ public class JWTUtil {
 
     public void validateToken(String token) {
         getClaims(token); // This will throw an exception if the token is invalid
-    }
-
-    public void validateToken(String token, String expectedKakaoId) {
-        validateToken(token); // Check if the token is valid
-        if (!getkakaoId(token).equals(expectedKakaoId)) {
-            throw new AuthException(INVALID_JWT_SIGNATURE);
-        }
     }
 }

--- a/src/main/java/com/turtledoctor/kgu/auth/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/turtledoctor/kgu/auth/oauth2/CustomSuccessHandler.java
@@ -45,7 +45,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         GrantedAuthority auth = iterator.next();
         String role = auth.getAuthority();
 
-        String token = jwtUtil.createJwt(KakaoId, name, email, role, 60*60*60*1000L);
+        String token = jwtUtil.createJwt(KakaoId, role, 60*60*60*1000L); // email, name 제거
 
         response.addHeader("Set-Cookie",createCookie("Authorization", token).toString());
 //        response.addHeader("QWWWW",token);

--- a/src/main/java/com/turtledoctor/kgu/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/turtledoctor/kgu/auth/service/CustomOAuth2UserService.java
@@ -26,7 +26,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
         OAuth2User oAuth2User = super.loadUser(userRequest);
-        System.out.println(oAuth2User);
+//        System.out.println(oAuth2User);
 
         OAuth2Response oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
 

--- a/src/main/java/com/turtledoctor/kgu/auth/service/MainService.java
+++ b/src/main/java/com/turtledoctor/kgu/auth/service/MainService.java
@@ -28,10 +28,12 @@ import static com.turtledoctor.kgu.exception.ErrorCode.*;
 public class MainService {
 
 
+
+
      @Value("${spring.jwt.secret}")
     String secret;
-        JWTUtil jwtUtil;
 
+     JWTUtil jwtUtil;
     private final MemberRepository memberRepository;
 
 
@@ -42,9 +44,9 @@ public class MainService {
             throw new AuthException(UNAUTHORIZED);
         }
         UserDTO userDTO = new UserDTO();
-        userDTO.setName(jwtUtil.getName(jwtToken));
+//        userDTO.setName(jwtUtil.getName(jwtToken)); // 제거
         userDTO.setKakaoId(jwtUtil.getkakaoId(jwtToken));
-        userDTO.setEmail(jwtUtil.getEmail(jwtToken));
+//        userDTO.setEmail(jwtUtil.getEmail(jwtToken)); // 제거
         userDTO.setRole(jwtUtil.getRole(jwtToken));
 
         Member member = memberRepository.findBykakaoId(userDTO.getKakaoId());
@@ -60,11 +62,15 @@ public class MainService {
     }
 
     public isLoginCheckDTO returnIsLogin(String jwtToken) {
+        jwtUtil = new JWTUtil(secret);
         isLoginCheckDTO isLoginCheckDTO = new isLoginCheckDTO();
         boolean value = true;
         if(jwtToken == null)
             value = false;
-        // 현재 문제. jwt 유효 검증을 하지 않음. cookie의 key만 Authorization이면 통과시키기 때문에 추후 보안을 생각하면 수정 필요.
+
+        // 아래 작업을 통해 jwt 존재 시 유효 검증
+        jwtUtil.validateToken(jwtToken);
+
         isLoginCheckDTO.setLoginStatus(value);
 
         return isLoginCheckDTO;


### PR DESCRIPTION
…cated 된 메서드 수정, api/isLogin 요청 시 jwt signiture 검증 로직 추가

<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #94 

## ✅ 작업 내용

- [ ] jwt 토큰 생성 시 name, email 민감한 정보 제거
- [ ] jwt signiture 검증 시 사용되던 deprecated 된 코드를 최신 버전에 맞게 수정
- [ ] api/isLogin으로 로그인 여부 검사하던 api에서 jwt signiture 검사를 추가로 수행하도록 수정.

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
